### PR TITLE
docs: debug and tls reject

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,8 @@ LOGGING_LEVEL_ROOT=ERROR
 LOGGING_LEVEL_ORG_SPRINGFRAMEWORK=ERROR
 
 # EvalCarbone SIH
+# Désactive la vérification des certificats SSL
+# NODE_TLS_REJECT_UNAUTHORIZED=0
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 REFERENTIELS_URL=http://localhost:18080
 EXPOSITION_DONNEES_ENTREES_URL=http://localhost:18081

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ docker compose --file docker-compose-front.yml --env-file .env.prod --env-file .
 docker compose up -d --force-recreate
 ```
 
+## Debugger Next-Auth
+
+Pour débugger Next-Auth, il faut ajouter modifier la variable d'environnement `NODE_ENV` avec une valeur `development` dans le fichier `.env.prod` et relancer les conteneurs.
+
+## Certificats non vérifiés
+
+Pour indiquer à NodeJS de ne pas vérifier les certificats, il faut ajouter la variable d'environnement `NODE_TLS_REJECT_UNAUTHORIZED=0` dans le fichier `.env.prod` et relancer les conteneurs.
+Cette variable permet d'indiquer à NodeJS de ne pas vérifier les certificats SSL lors des appels API.
 
 ### Schéma de la production
 


### PR DESCRIPTION
## Purpose

This PR includes some details around:
- How to put Next-Auth in debug mode
- Disable NodeJS TLS Cert verification