### PR TITLE
fix: update Docker images to use legacy Bitnami versions for Zookeepe…

### DIFF
--- a/infra/roles/backend/files/docker-compose.yml
+++ b/infra/roles/backend/files/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   zookeeper:
-    image: docker.io/bitnami/zookeeper:3.9
+    image: docker.io/bitnamilegacy/zookeeper:3.9
     container_name: zookeeper
     networks:
       - eval-carbone
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
 
   kafka:
-    image: docker.io/bitnami/kafka:3.6
+    image: docker.io/bitnamilegacy/kafka:3.6
     container_name: kafka
     networks:
       - eval-carbone


### PR DESCRIPTION
This pull request updates the Docker images used for `zookeeper` and `kafka` services in the `infra/roles/backend/files/docker-compose.yml` file. The main change is switching from the `bitnami` image repository to the `bitnamilegacy` repository for both services.

Container image updates:

* Changed the `zookeeper` service image from `docker.io/bitnami/zookeeper:3.9` to `docker.io/bitnamilegacy/zookeeper:3.9` to use the legacy image repository.
* Changed the `kafka` service image from `docker.io/bitnami/kafka:3.6` to `docker.io/bitnamilegacy/kafka:3.6` to use the legacy image repository.